### PR TITLE
Corrected misspell of *Solvert* to *Solver*.

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,0 +1,11 @@
+2020. 7. 3. Corrected misspell of *Solvert* to *Solver*. [rkfd_mlcp]
+2020. 7. 3. Corrected misspell of *Safaty* to *Safety*. [rkfd_volume]
+2020. 7. 3. Corrected misspell of *Solveer* to *Solver*. [rkfd_vert]
+2020. 7. 3. Reflected renaming of some members of rkJoint. [rkfd_sim, rkfd_util]
+2020. 7. 3. Renamed fric_weight, rkFDPrpFricWeight and rkFDPrpSetFricWeight of rkFDPrp to friction_weight, rkFDPrpFrictionWeight and rkFDPrpSetFrictionWeight, respectively. [rkfd_property, rkfd_util, rkfd_vert, rkfd_volume, rkfd_mlcp]
+2020. 7. 3. Renamed RK_FD_KINETIC_FRIC_WEIGHT_DEFAULT and RK_FD_FRIC_PYRAMID_ORDER_DEFAULT to RK_FD_KINETIC_FRICTION_WEIGHT_DEFAULT and RK_FD_FRICTION_PYRAMID_ORDER_DEFAULT, respectively. [rkfd_defs]
+2020. 7. 3. Renamed rkFDSolverUpdateRefWithAcc_* to rkFDSolverUpdatePrevDrivingTrq_* [rkfd_vert, rkfd_volume, rkfd_mlcp, rkfd_solver, rkfd_sim]
+2020. 7. 3. Renamed rkFDUpdateJointRefDrivingTrq to rkFDUpdateJointPrevDrivingTrq. [rkfd_util, rkfd_vert]
+2020. 7. 3. Renamed _rkFDCellDatJointRefInit to _rkFDCellDatJointFrictionPivotInit. [rkfd_sim]
+2020. 7. 2. Reflected new specifications of ZEDA, Zeo and RoKi. [rkfd_sim, rkfd_util, rkfd_cd, rkfd_vert, rkfd_volume, rkfd_mlcp]
+2018. 7. 9. Separated from RoKi by Naoki Wakisaka.

--- a/config.org
+++ b/config.org
@@ -1,5 +1,5 @@
 PREFIX=$(HOME)/usr
 PROJNAME=roki-fd
-VERSION=1.2.1
+VERSION=1.2.2
 
-DEPENDENCY="zeda=1.2.1;zm=1.2.1;zeo=1.3.2;roki=1.3.2"
+DEPENDENCY="zeda=1.2.19;zm=1.2.9;zeo=1.4.9;roki=1.3.21"

--- a/include/roki-fd/rkfd_array.h
+++ b/include/roki-fd/rkfd_array.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
- * rkfd_array -
- * contributer: 2014-2018 Naoki Wakisaka
+ * rkfd_array - utility for array manipulation
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_ARRAY_H__

--- a/include/roki-fd/rkfd_cd.h
+++ b/include/roki-fd/rkfd_cd.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_cd - collision detection class
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_CD_H__

--- a/include/roki-fd/rkfd_chain.h
+++ b/include/roki-fd/rkfd_chain.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_chain - derived chain class
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_CHAIN_H__

--- a/include/roki-fd/rkfd_defs.h
+++ b/include/roki-fd/rkfd_defs.h
@@ -1,23 +1,23 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
- * rkfd_def - definitions
- * contributer: 2014-2018 Naoki Wakisaka
+ * rkfd_defs - definitions of default parameters
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_DEFS_H__
 #define __RKFD_DEFS_H__
 
-#define RK_FD_DT_DEFAULT           0.001
-#define RK_FD_CDT_DEFAULT          0.002
-#define RK_FD_JOINT_COMP_K_DEFAULT 100
-#define RK_FD_JOINT_COMP_L_DEFAULT 0.01
-#define RK_FD_KINETIC_FRIC_WEIGHT_DEFAULT 100
-#define RK_FD_FRIC_PYRAMID_ORDER_DEFAULT 8
-
-#define RK_FD_MAX_ITER_DEFAULT 10
-#define RK_FD_VEL_EPSILON_DEFAULT 1e-8
-
 #include <zeda/zeda.h>
+
+#define RK_FD_DT_DEFAULT                        0.001
+#define RK_FD_CDT_DEFAULT                       0.002
+#define RK_FD_JOINT_COMP_K_DEFAULT            100
+#define RK_FD_JOINT_COMP_L_DEFAULT              0.01
+#define RK_FD_KINETIC_FRICTION_WEIGHT_DEFAULT 100
+#define RK_FD_FRICTION_PYRAMID_ORDER_DEFAULT    8
+
+#define RK_FD_MAX_ITER_DEFAULT                 10
+#define RK_FD_VEL_EPSILON_DEFAULT              (1.0e-8)
 
 #endif /* __RKFD_DEFS_H__ */

--- a/include/roki-fd/rkfd_mlcp.h
+++ b/include/roki-fd/rkfd_mlcp.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
- * rkfd_mlcp -
- * contributer: 2014-2018 Naoki Wakisaka
+ * rkfd_mlcp - LCP based formulation with Projected Gauss Seidel method.
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_MLCP_H__
@@ -24,8 +24,8 @@ typedef struct{
   rkWrench *w[2];
 } rkFDSolverPrpMLCP;
 
- RKFD_SOLVER_FUNCTION_DEFAULT( MLCP )
- RKFD_SOLVER_CREATE_DEFAULT( MLCP )
+RKFD_SOLVER_FUNCTION_DEFAULT( MLCP )
+RKFD_SOLVER_CREATE_DEFAULT( MLCP )
 
 __END_DECLS
 

--- a/include/roki-fd/rkfd_penalty.h
+++ b/include/roki-fd/rkfd_penalty.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
- * rkfd_penalty -
- * contributer: 2014-2018 Naoki Wakisaka
+ * rkfd_penalty - contact force computation based on penalty method
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_PENALTY_H__

--- a/include/roki-fd/rkfd_property.h
+++ b/include/roki-fd/rkfd_property.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_property - properties for forward dynamics simulation
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_PROPERTY_H__
@@ -15,23 +15,23 @@ __BEGIN_DECLS
 typedef struct{
   double dt;
   int pyramid;
-  double fric_weight;
+  double friction_weight;
 
   int max_iter;
   double vel_eps;
 } rkFDPrp;
 
-#define rkFDPrpDT(p)         (p)->dt
-#define rkFDPrpPyramid(p)    (p)->pyramid
-#define rkFDPrpFricWeight(p) (p)->fric_weight
-#define rkFDPrpMaxIter(p)    (p)->max_iter
-#define rkFDPrpVelEps(p)     (p)->vel_eps
+#define rkFDPrpDT(p)             (p)->dt
+#define rkFDPrpPyramid(p)        (p)->pyramid
+#define rkFDPrpFrictionWeight(p) (p)->friction_weight
+#define rkFDPrpMaxIter(p)        (p)->max_iter
+#define rkFDPrpVelEps(p)         (p)->vel_eps
 
-#define rkFDPrpSetDT(f,t)         ( (f)->prp.dt = (t) )
-#define rkFDPrpSetPyramid(f,n)    ( (f)->prp.pyramid = (n) )
-#define rkFDPrpSetFricWeight(f,w) ( (f)->prp.fric_weight = (w) )
-#define rkFDPrpSetMaxIter(f,i)    ( (f)->prp.max_iter = (i) )
-#define rkFDPrpSetVelEps(f,e)     ( (f)->prp.vel_eps = (e) )
+#define rkFDPrpSetDT(f,t)             ( (f)->prp.dt = (t) )
+#define rkFDPrpSetPyramid(f,n)        ( (f)->prp.pyramid = (n) )
+#define rkFDPrpSetFrictionWeight(f,w) ( (f)->prp.friction_weight = (w) )
+#define rkFDPrpSetMaxIter(f,i)        ( (f)->prp.max_iter = (i) )
+#define rkFDPrpSetVelEps(f,e)         ( (f)->prp.vel_eps = (e) )
 
 __EXPORT bool rkFDPrpInit(rkFDPrp *prp);
 __EXPORT void rkFDPrpDestroy(rkFDPrp *prp);

--- a/include/roki-fd/rkfd_sim.h
+++ b/include/roki-fd/rkfd_sim.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_sim - forward dynamics simulation
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_SIM_H__
@@ -38,11 +38,11 @@ zListClass( rkFDCellList, rkFDCell, rkFDCellDat );
 typedef struct _rkFD{
   double t;
   rkFDPrp prp;
-  rkFDSolver solver;    /* solver */
-  rkFDCellList list;    /* chain list */
-  rkContactInfoPool ci; /* contact information list */
-  rkContactInfo cidef;  /* default contact infomation */
-  rkFDCD cd;            /* contact maneger */
+  rkFDSolver solver;     /* solver */
+  rkFDCellList list;     /* chain list */
+  rkContactInfoArray ci; /* contact information list */
+  rkContactInfo cidef;   /* default contact infomation */
+  rkFDCD cd;             /* contact maneger */
 
   zODE2 ode;
   int ode_step;

--- a/include/roki-fd/rkfd_solver.h
+++ b/include/roki-fd/rkfd_solver.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_solver - contact force computation solver
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_SOLVER_H__
@@ -56,7 +56,7 @@ __EXPORT void rkFDSolverDestroy(rkFDSolver *solver);
 #define rkFDSolverUpdateInit(s)              (s)->com->_init(s)
 #define rkFDSolverColChk(s,b)                (s)->com->_colchk(s,b)
 #define rkFDSolverUpdate(s,b)                (s)->com->_update(s,b)
-#define rkFDSolverUpdateRefWithAcc(s)        (s)->com->_update_ref(s)
+#define rkFDSolverUpdatePrevDrivingTrq(s)    (s)->com->_update_ref(s)
 #define rkFDSolverUpdateDestroy(s)           (s)->com->_destroy(s)
 
 /* **********************************************************
@@ -77,7 +77,7 @@ __EXPORT void rkFDSolverDestroy(rkFDSolver *solver);
  * bool rkFDSolverUpdateInit_Vert(rkFDSolver *s){...}
  * void rkFDSolverColChk_Vert(rkFDSolver *s, bool doUpRef){...}
  * bool rkFDSolverUpdate_Vert(rkFDSolver *s, bool doUpRef){...}
- * void rkFDSolverUpdateRefWithAcc_Vert(rkFDSolver *s){...}
+ * void rkFDSolverUpdatePrevDrivingTrq_Vert(rkFDSolver *s){...}
  * void rkFDSolverUpdateDestroy_Vert(rkFDSolver *s){...}
  *
  * RKFD_SOLVER_DEFAULT_GENERATOR( Vert )
@@ -87,7 +87,7 @@ __EXPORT void rkFDSolverDestroy(rkFDSolver *solver);
   bool rkFDSolverUpdateInit_##type(rkFDSolver *s);                      \
   void rkFDSolverColChk_##type(rkFDSolver *s, bool doUpRef);            \
   bool rkFDSolverUpdate_##type(rkFDSolver *s, bool doUpRef);            \
-  void rkFDSolverUpdateRefWithAcc_##type(rkFDSolver *s);                \
+  void rkFDSolverUpdatePrevDrivingTrq_##type(rkFDSolver *s);            \
   void rkFDSolverUpdateDestroy_##type(rkFDSolver *s);
 
 #define RKFD_SOLVER_FUNCTION_DEFAULT_INST(type) \
@@ -96,7 +96,7 @@ __EXPORT void rkFDSolverDestroy(rkFDSolver *solver);
     rkFDSolverUpdateInit_##type,                \
     rkFDSolverColChk_##type,                    \
     rkFDSolverUpdate_##type,                    \
-    rkFDSolverUpdateRefWithAcc_##type,          \
+    rkFDSolverUpdatePrevDrivingTrq_##type,      \
     rkFDSolverUpdateDestroy_##type              \
   };
 

--- a/include/roki-fd/rkfd_util.h
+++ b/include/roki-fd/rkfd_util.h
@@ -1,8 +1,8 @@
-/* RoKi - Robot Kinetics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_util - utility functions for forward dynamics computation
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_UTIL_H__
@@ -48,7 +48,7 @@ __EXPORT void rkFDContactForceModifyFriction(rkFDPrp *prp, rkCDPairDat *pd, rkCD
 __EXPORT void rkFDContactForcePushWrench(rkCDPairDat *pd, rkCDVert *cdv);
 
 /******************************************************************************/
-__EXPORT void rkFDUpdateJointRefDrivingTrq(rkFDChainArray *chains);
+__EXPORT void rkFDUpdateJointPrevDrivingTrq(rkFDChainArray *chains);
 __EXPORT void rkFDJointFrictionAll(rkJoint *joint, double weight);
 __EXPORT void rkFDJointFrictionRevolDC(rkJoint *joint, double dt, bool doUpRef);
 __EXPORT void rkFDJointFriction(rkFDChainArray *chains, double dt, double weight, bool doUpRef);

--- a/include/roki-fd/rkfd_vert.h
+++ b/include/roki-fd/rkfd_vert.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
- * rkfd_vert -
- * contributer: 2014-2018 Naoki Wakisaka
+ * rkfd_vert - vertex / plane contact model
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_VERT_H__
@@ -29,8 +29,8 @@ typedef struct{
   rkWrench *w[2];
 } rkFDSolverPrpVert;
 
- RKFD_SOLVER_FUNCTION_DEFAULT( Vert )
- RKFD_SOLVER_CREATE_DEFAULT( Vert )
+RKFD_SOLVER_FUNCTION_DEFAULT( Vert )
+RKFD_SOLVER_CREATE_DEFAULT( Vert )
 
 __END_DECLS
 

--- a/include/roki-fd/rkfd_volume.h
+++ b/include/roki-fd/rkfd_volume.h
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
- * rkfd_volume -
- * contributer: 2014-2018 Naoki Wakisaka
+ * rkfd_volume - volumetric contact model
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #ifndef __RKFD_VOLUME_H__
@@ -33,8 +33,8 @@ typedef struct{
   zVec mb, mc, mf;
 } rkFDSolverPrpVolume;
 
- RKFD_SOLVER_FUNCTION_DEFAULT( Volume )
- RKFD_SOLVER_CREATE_DEFAULT( Volume )
+RKFD_SOLVER_FUNCTION_DEFAULT( Volume )
+RKFD_SOLVER_CREATE_DEFAULT( Volume )
 
 __END_DECLS
 

--- a/include/roki-fd/rokifd.h
+++ b/include/roki-fd/rokifd.h
@@ -1,6 +1,6 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 /*!

--- a/src/makefile
+++ b/src/makefile
@@ -8,9 +8,15 @@ CC=gcc
 CFLAGS=-ansi -Wall -Werror -fPIC -O3 $(INCLUDE) -funroll-loops
 LD=gcc
 LDFLAGS=-shared
-SIGNUP=echo "Roki-FD ver."$(VERSION)" Copyright (C) 2018 Tomomichi Sugihara (Zhidao)" >>
+SIGNUP=echo "RoKi-FD ver."$(VERSION)" Copyright (C) 2018 Tomomichi Sugihara (Zhidao)" >>
 
-OBJ=rkfd_sim.o rkfd_util.o rkfd_cd.o rkfd_penalty.o rkfd_property.o rkfd_solver.o rkfd_vert.o rkfd_volume.o rkfd_mlcp.o
+OBJ=rkfd_property.o\
+	rkfd_cd.o\
+	rkfd_solver.o\
+	rkfd_util.o\
+	rkfd_sim.o\
+	rkfd_penalty.o\
+	rkfd_vert.o rkfd_volume.o rkfd_mlcp.o
 DLIB=librokifd.so
 
 TARGET=$(DLIB)

--- a/src/rkfd_cd.c
+++ b/src/rkfd_cd.c
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_cd - collision detection class
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #include <roki-fd/rkfd_cd.h>
@@ -19,12 +19,12 @@ void rkFDCDDestroy(rkFDCD *cd)
   rkCDDestroy( &cd->cd );
 }
 
-bool rkFDCDUpdateInit(rkFDCD *cd){
-  if( zListNum( &cd->cd.plist ) == 0 )
-    return true;
+bool rkFDCDUpdateInit(rkFDCD *cd)
+{
+  if( zListSize( &cd->cd.plist ) == 0 ) return true;
 
-  zArrayAlloc( &cd->elast_pairs, rkCDPairDat*, zListNum( &cd->cd.plist ) );
-  zArrayAlloc( &cd->rigid_pairs, rkCDPairDat*, zListNum( &cd->cd.plist ) );
+  zArrayAlloc( &cd->elast_pairs, rkCDPairDat*, zListSize( &cd->cd.plist ) );
+  zArrayAlloc( &cd->rigid_pairs, rkCDPairDat*, zListSize( &cd->cd.plist ) );
   if( zArraySize( &cd->elast_pairs ) == 0 || zArraySize( &cd->rigid_pairs ) == 0 )
     return false;
   return true;
@@ -53,4 +53,3 @@ void rkFDCDUpdateDestroy(rkFDCD *cd)
   zArrayFree( &cd->elast_pairs );
   zArrayFree( &cd->rigid_pairs );
 }
-

--- a/src/rkfd_penalty.c
+++ b/src/rkfd_penalty.c
@@ -1,3 +1,10 @@
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
+ * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
+ *
+ * rkfd_penalty - contact force computation based on penalty method
+ * additional contributer: 2014- Naoki Wakisaka
+ */
+
 #include <roki-fd/rkfd_penalty.h>
 #include <roki-fd/rkfd_util.h>
 

--- a/src/rkfd_property.c
+++ b/src/rkfd_property.c
@@ -1,18 +1,19 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_property - properties for forward dynamics simulation
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #include <roki-fd/rkfd_property.h>
 
-bool rkFDPrpInit(rkFDPrp *prp){
-  prp->dt          = RK_FD_DT_DEFAULT;
-  prp->pyramid     = RK_FD_FRIC_PYRAMID_ORDER_DEFAULT;
-  prp->fric_weight = RK_FD_KINETIC_FRIC_WEIGHT_DEFAULT;
-  prp->max_iter    = RK_FD_MAX_ITER_DEFAULT;
-  prp->vel_eps     = RK_FD_VEL_EPSILON_DEFAULT;
+bool rkFDPrpInit(rkFDPrp *prp)
+{
+  prp->dt              = RK_FD_DT_DEFAULT;
+  prp->pyramid         = RK_FD_FRICTION_PYRAMID_ORDER_DEFAULT;
+  prp->friction_weight = RK_FD_KINETIC_FRICTION_WEIGHT_DEFAULT;
+  prp->max_iter        = RK_FD_MAX_ITER_DEFAULT;
+  prp->vel_eps         = RK_FD_VEL_EPSILON_DEFAULT;
   return true;
 }
 

--- a/src/rkfd_solver.c
+++ b/src/rkfd_solver.c
@@ -1,8 +1,8 @@
-/* RoKiFD - Robot Forward Dynamics library
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
  * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
  *
  * rkfd_solver - contact force computation solver
- * contributer: 2014-2018 Naoki Wakisaka
+ * additional contributer: 2014- Naoki Wakisaka
  */
 
 #include <roki-fd/rkfd_solver.h>

--- a/src/rkfd_vert.c
+++ b/src/rkfd_vert.c
@@ -1,9 +1,15 @@
+/* RoKi-FD - Robot Kinetics library: forward dynamics extention
+ * Copyright (C) 1998 Tomomichi Sugihara (Zhidao)
+ *
+ * rkfd_vert - vertex / plane contact model
+ * additional contributer: 2014- Naoki Wakisaka
+ */
+
 #include <roki-fd/rkfd_util.h>
 #include <roki-fd/rkfd_vert.h>
 #include <roki-fd/rkfd_penalty.h>
 
-/* vertex based computation
- * the friction states are determined based on the computed friction forces one step before.
+/* the friction states are determined based on the computed friction forces one step before.
  * the direction of the kinetic friction is not fixed.
  */
 /* ************************************************************************** */
@@ -12,19 +18,18 @@
 #define _prp(s) ( (rkFDSolverPrpVert* )((s)->prp) )
 
 /* count rigid contact vertics */
-static void _rkFDSolverCountContacts(rkFDSolver *s);
-void _rkFDSolverCountContacts(rkFDSolver *s)
+static void _rkFDSolverCountContacts(rkFDSolver *s)
 {
   rkCDPairDat **pd;
 
   _prp(s)->colnum = 0;
   rkFDCDForEachRigidPair( s->cd, pd )
-    _prp(s)->colnum += zListNum(&(*pd)->vlist);
+    _prp(s)->colnum += zListSize(&(*pd)->vlist);
 }
 
 /* allocate workspace */
-static bool _rkFDSolverPrpReAlloc(rkFDSolver *s);
-bool _rkFDSolverPrpReAlloc(rkFDSolver *s){
+static bool _rkFDSolverPrpReAlloc(rkFDSolver *s)
+{
   int fnum = 3*_prp(s)->colnum;
   int cnum = rkFDPrpPyramid(s->fdprp) * _prp(s)->colnum;
 
@@ -43,7 +48,6 @@ bool _rkFDSolverPrpReAlloc(rkFDSolver *s){
     _prp(s)->nf      = zMatAlloc( cnum, fnum );
     _prp(s)->d       = zVecAlloc( cnum );
     _prp(s)->idx     = zIndexCreate( cnum );
-
     if( !_prp(s)->a || !_prp(s)->q || !_prp(s)->nf || !_prp(s)->b || !_prp(s)->t || !_prp(s)->c || !_prp(s)->d || !_prp(s)->f || !_prp(s)->idx ){
       zMatFreeAO( 3, _prp(s)->a, _prp(s)->q, _prp(s)->nf );
       zVecFreeAO( 5, _prp(s)->b, _prp(s)->t, _prp(s)->c, _prp(s)->d, _prp(s)->f );
@@ -65,8 +69,8 @@ bool _rkFDSolverPrpReAlloc(rkFDSolver *s){
 }
 
 /* friction constraint */
-static void _rkFDSolverFrictionConstraint(rkFDSolver *s);
-void _rkFDSolverFrictionConstraint(rkFDSolver *s){
+static void _rkFDSolverFrictionConstraint(rkFDSolver *s)
+{
   rkCDPairDat **pd;
   rkCDVert *cdv;
   register int i;
@@ -98,10 +102,8 @@ void _rkFDSolverFrictionConstraint(rkFDSolver *s){
 }
 
 /* relation between acc and force */
-static void _rkFDSolverBiasAcc(rkFDSolver *s, zVec acc);
-static void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec a);
-static void _rkFDSolverRelationAccForce(rkFDSolver *s);
-void _rkFDSolverBiasAcc(rkFDSolver *s, zVec acc)
+
+static void _rkFDSolverBiasAcc(rkFDSolver *s, zVec acc)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
@@ -119,7 +121,7 @@ void _rkFDSolverBiasAcc(rkFDSolver *s, zVec acc)
   }
 }
 
-void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec a)
+static void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec a)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
@@ -132,7 +134,7 @@ void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec a)
         (*pd)->cell[0]->data.chain != cpd->cell[1]->data.chain &&
         (*pd)->cell[1]->data.chain != cpd->cell[0]->data.chain &&
         (*pd)->cell[1]->data.chain != cpd->cell[1]->data.chain ){
-      for( i=0; i<zListNum(&(*pd)->vlist); i++ ){
+      for( i=0; i<zListSize(&(*pd)->vlist); i++ ){
         zVec3DZero( (zVec3D *)&zVecElemNC(a,offset) );
         offset += 3;
       }
@@ -147,7 +149,7 @@ void _rkFDSolverRelativeAcc(rkFDSolver *s, rkCDPairDat *cpd, zVec b, zVec a)
   }
 }
 
-void _rkFDSolverRelationAccForce(rkFDSolver *s)
+static void _rkFDSolverRelationAccForce(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
@@ -182,14 +184,8 @@ void _rkFDSolverRelationAccForce(rkFDSolver *s)
 }
 
 /* solve QP */
-static void _rkFDSolverBiasVel(rkFDSolver *s);
-static void _rkFDSolverCompensateDepth(rkFDSolver *s);
-static zVec _rkFDSolveerQPASMInit(rkFDSolver *s, zVec ans);
-static double _rkFDSolverQPASMCond(zMat a, zVec ans, int i, void *util);
-static void _rkFDSolveerQPASM(rkFDSolver *s);
-static void _rkFDSolverQP(rkFDSolver *s);
 
-void _rkFDSolverBiasVel(rkFDSolver *s)
+static void _rkFDSolverBiasVel(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
@@ -208,7 +204,7 @@ void _rkFDSolverBiasVel(rkFDSolver *s)
   }
 }
 
-void _rkFDSolverCompensateDepth(rkFDSolver *s)
+static void _rkFDSolverCompensateDepth(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
@@ -234,7 +230,7 @@ void _rkFDSolverCompensateDepth(rkFDSolver *s)
   }
 }
 
-zVec _rkFDSolveerQPASMInit(rkFDSolver *s, zVec ans)
+static zVec _rkFDSolverQPASMInit(rkFDSolver *s, zVec ans)
 {
   register int i;
 
@@ -244,7 +240,7 @@ zVec _rkFDSolveerQPASMInit(rkFDSolver *s, zVec ans)
   return ans;
 }
 
-double _rkFDSolverQPASMCond(zMat a, zVec ans, int i, void *util)
+static double _rkFDSolverQPASMCond(zMat a, zVec ans, int i, void *util)
 {
   int n = i / ( rkFDPrpPyramid(((rkFDSolver *)util)->fdprp) );
   return zVec3DInnerProd( (zVec3D *)&zMatElemNC(a,i,3*n), (zVec3D *)&zVecElemNC(ans,3*n) );
@@ -252,14 +248,15 @@ double _rkFDSolverQPASMCond(zMat a, zVec ans, int i, void *util)
 
 /* wapper of ASM */
 extern void _zQPSolveASM(zMat q, zVec c, zMat a, zVec b, zVec ans, zIndex idx, void *util, double cond(zMat,zVec,int,void*));
-void _rkFDSolveerQPASM(rkFDSolver *s)
+
+static void _rkFDSolverQPASM(rkFDSolver *s)
 {
-  _rkFDSolveerQPASMInit( s, _prp(s)->f );
+  _rkFDSolverQPASMInit( s, _prp(s)->f );
   _zQPSolveASM( _prp(s)->q, _prp(s)->c, _prp(s)->nf, _prp(s)->d, _prp(s)->f, _prp(s)->idx, s, _rkFDSolverQPASMCond );
 }
 
 /* Quadratic Problem */
-void _rkFDSolverQP(rkFDSolver *s)
+static void _rkFDSolverQP(rkFDSolver *s)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
@@ -281,15 +278,13 @@ void _rkFDSolverQP(rkFDSolver *s)
       offset += 3;
     }
   }
-
   /* solve */
-  _rkFDSolveerQPASM( s );
+  _rkFDSolverQPASM( s );
   zVecDivDRC( _prp(s)->f, rkFDPrpDT(s->fdprp) );
 }
 
 /* set force and update friction type */
-static void _rkFDSolverSetForce(rkFDSolver *s, bool doUpRef);
-void _rkFDSolverSetForce(rkFDSolver *s, bool doUpRef)
+static void _rkFDSolverSetForce(rkFDSolver *s, bool doUpRef)
 {
   rkCDPairDat **pd;
   rkCDVert *cdv;
@@ -330,8 +325,7 @@ void _rkFDSolverSetForce(rkFDSolver *s, bool doUpRef)
 }
 
 /*****************************************************************************/
-static bool _rkFDSolverConstraint(rkFDSolver *s, bool doUpRef);
-bool _rkFDSolverConstraint(rkFDSolver *s, bool doUpRef)
+static bool _rkFDSolverConstraint(rkFDSolver *s, bool doUpRef)
 {
   _rkFDSolverCountContacts( s );
   if( !_rkFDSolverPrpReAlloc( s ) ) return false;
@@ -354,7 +348,8 @@ void rkFDSolverGetDefaultContactInfo_Vert(rkFDSolver *s, rkContactInfo *ci)
   rkContactInfoSetKF( ci, 0.3 );
 }
 
-bool rkFDSolverUpdateInit_Vert(rkFDSolver *s){
+bool rkFDSolverUpdateInit_Vert(rkFDSolver *s)
+{
   _prp(s)->colnum = 0;
   _prp(s)->a = NULL;
   _prp(s)->b = NULL;
@@ -375,7 +370,8 @@ bool rkFDSolverUpdateInit_Vert(rkFDSolver *s){
   return rkFDCrateSinCosTable( _prp(s)->sc_table, rkFDPrpPyramid(s->fdprp), -zDeg2Rad( 180.0 ) / rkFDPrpPyramid(s->fdprp) );
 }
 
-void rkFDSolverColChk_Vert(rkFDSolver *s, bool doUpRef){
+void rkFDSolverColChk_Vert(rkFDSolver *s, bool doUpRef)
+{
   zEchoOff();
   /* if( doUpRef ) */
   rkCDColChkVert( rkFDCDBase(rkFDSolverCD(s)) );
@@ -384,7 +380,7 @@ void rkFDSolverColChk_Vert(rkFDSolver *s, bool doUpRef){
 
 bool rkFDSolverUpdate_Vert(rkFDSolver *s, bool doUpRef)
 {
-  rkFDJointFriction( rkFDSolverChains(s), rkFDPrpDT(s->fdprp), rkFDPrpFricWeight(s->fdprp), doUpRef );
+  rkFDJointFriction( rkFDSolverChains(s), rkFDPrpDT(s->fdprp), rkFDPrpFrictionWeight(s->fdprp), doUpRef );
   if( rkFDCDElastNum(s->cd) != 0 )
     rkFDSolverPenalty( s, doUpRef );
   if( rkFDCDRigidNum(s->cd) != 0 )
@@ -392,8 +388,9 @@ bool rkFDSolverUpdate_Vert(rkFDSolver *s, bool doUpRef)
   return true;
 }
 
-void rkFDSolverUpdateRefWithAcc_Vert(rkFDSolver *s){
-  rkFDUpdateJointRefDrivingTrq( rkFDSolverChains(s) );
+void rkFDSolverUpdatePrevDrivingTrq_Vert(rkFDSolver *s)
+{
+  rkFDUpdateJointPrevDrivingTrq( rkFDSolverChains(s) );
 }
 
 void rkFDSolverUpdateDestroy_Vert(rkFDSolver *s){


### PR DESCRIPTION
developに投げ直します。
Corrected misspell of *Safaty* to *Safety*.
Corrected misspell of *Solveer* to *Solver*.
Reflected renaming of some members of rkJoint.
Renamed fric_weight, rkFDPrpFricWeight and rkFDPrpSetFricWeight of rkFDPrp to friction_weight, rkFDPrpFrictionWeight and rkFDPrpSetFrictionWeight, respectively.
Renamed RK_FD_KINETIC_FRIC_WEIGHT_DEFAULT and RK_FD_FRIC_PYRAMID_ORDER_DEFAULT to RK_FD_KINETIC_FRICTION_WEIGHT_DEFAULT and RK_FD_FRICTION_PYRAMID_ORDER_DEFAULT, respectively.
Renamed rkFDSolverUpdateRefWithAcc_* to rkFDSolverUpdatePrevDrivingTrq_*
Renamed rkFDUpdateJointRefDrivingTrq to rkFDUpdateJointPrevDrivingTrq.
Renamed _rkFDCellDatJointRefInit to _rkFDCellDatJointFrictionPivotInit.
Reflected new specifications of ZEDA, Zeo and RoKi.